### PR TITLE
Disable most of pre-commit checks during PR presubmit

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -11,3 +11,4 @@ presubmits:
             - "pre-commit"
             - "run"
             - "--all-files"
+            - "detect-private-key"


### PR DESCRIPTION
As discussed in the tech talk yesterday: the goal of this PR is to disable (most of) the pre-commit checks that prow runs on PRs (by running only one specific hook and not the others) in order to facilitate the hackmd->repo flow.

The idea is:
- PRs that come from a _sync_ from hackmd are not subject to pre-commit lint/tab/etc checks. We can live with some extra spaces in the README for a while, and we (should) know that things look well in hackmd
- PRs created by individuals should still take care of running `pre-commit` locally before submitting the PR

**Note**: the pre-commit check can not be completely disabled because the current prow configuration [requires it to pass](https://github.com/operate-first/apps/blob/82d003126261beea7676f8eb480a121284da6b6c/prow/overlays/smaug/config.yaml#L84-L92) before merging to main. An alternative could be to remove this repo's branch protection
